### PR TITLE
Do not hardcode scenes : allows rendering any scene

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,10 @@
-﻿/.idea/
+/.idea/
+.vs/
+.vscode/
+
 /data/
 
 bin/
 obj/
 
 *.user
-
-.vs/

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 /.idea/
-.vs/
-.vscode/
+/.vs/
+/.vscode/
 
 /data/
 

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ bin/
 obj/
 
 *.user
+
+.vs/

--- a/Overtone.Game/Config/WindowsConfiguration.fs
+++ b/Overtone.Game/Config/WindowsConfiguration.fs
@@ -171,3 +171,8 @@ type WindowsConfiguration = {
         |> Seq.filter(fun e -> e.States.Contains stateId)
         |> Seq.map(fun e -> e.Name, e)
         |> Map.ofSeq
+
+    member this.GetControlsArray(stateId: int): WindowEntry[] =
+        this.Entries
+        |> Seq.filter(fun e -> e.States.Contains stateId)
+        |> Seq.toArray

--- a/Overtone.Game/Overtone.Game.fsproj
+++ b/Overtone.Game/Overtone.Game.fsproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
@@ -16,7 +16,7 @@
         <Compile Include="Input\Mouse.fs" />
         <Compile Include="Windows\Controls.fs" />
         <Compile Include="Windows\Sparkles.fs" />
-        <Compile Include="Windows\MenuScene.fs" />
+        <Compile Include="Windows\MainScene.fs" />
         <Compile Include="OvertoneGame.fs" />
         <Compile Include="Program.fs" />
     </ItemGroup>

--- a/Overtone.Game/OvertoneGame.fs
+++ b/Overtone.Game/OvertoneGame.fs
@@ -7,7 +7,6 @@ open Microsoft.Xna.Framework.Input
 open Overtone.Game.Config
 open Overtone.Game.Input
 open Overtone.Game.Windows
-open Overtone.Game.Logics
 open Overtone.Resources
 
 type OvertoneGame(disc: GameDisc, shapesConfig: ShapesConfiguration, windowConfig: WindowsConfiguration) as this =

--- a/Overtone.Game/OvertoneGame.fs
+++ b/Overtone.Game/OvertoneGame.fs
@@ -4,6 +4,7 @@ open JetBrains.Lifetimes
 open Microsoft.Xna.Framework
 open Microsoft.Xna.Framework.Input
 
+open Overtone.Game.Constants
 open Overtone.Game.Config
 open Overtone.Game.Input
 open Overtone.Game.Windows
@@ -26,7 +27,7 @@ type OvertoneGame(disc: GameDisc, shapesConfig: ShapesConfiguration, windowConfi
 
     override this.Initialize() =
         this.Window.Title <- "Overtone"
-        scene.Value.changeSceneId 0
+        scene.Value.changeSceneId Scenes.MainMenu
 
         graphics.PreferredBackBufferWidth <- 640
         graphics.PreferredBackBufferHeight <- 480

--- a/Overtone.Game/OvertoneGame.fs
+++ b/Overtone.Game/OvertoneGame.fs
@@ -1,4 +1,4 @@
-﻿namespace Overtone.Game
+namespace Overtone.Game
 
 open JetBrains.Lifetimes
 open Microsoft.Xna.Framework
@@ -7,6 +7,7 @@ open Microsoft.Xna.Framework.Input
 open Overtone.Game.Config
 open Overtone.Game.Input
 open Overtone.Game.Windows
+open Overtone.Game.Logics
 open Overtone.Resources
 
 type OvertoneGame(disc: GameDisc, shapesConfig: ShapesConfiguration, windowConfig: WindowsConfiguration) as this =
@@ -22,10 +23,11 @@ type OvertoneGame(disc: GameDisc, shapesConfig: ShapesConfiguration, windowConfi
         this.GraphicsDevice,
         (disc.ReadFile "THING1/FLOAT.EXE").Result // TODO[#35]: Show a loader at start instead of .Result
     )
-    let scene = lazy MenuScene(lifetime, this.GraphicsDevice, textureManager.Value, windowConfig)
+    let scene = lazy MainScene(lifetime, this.GraphicsDevice, textureManager.Value, windowConfig)
 
     override this.Initialize() =
         this.Window.Title <- "Overtone"
+        scene.Value.changeSceneId 0
 
         graphics.PreferredBackBufferWidth <- 640
         graphics.PreferredBackBufferHeight <- 480

--- a/Overtone.Game/Windows/Controls.fs
+++ b/Overtone.Game/Windows/Controls.fs
@@ -1,4 +1,4 @@
-namespace Overtone.Game.Windows
+﻿namespace Overtone.Game.Windows
 
 open JetBrains.Lifetimes
 open Microsoft.Xna.Framework
@@ -7,6 +7,7 @@ open Microsoft.Xna.Framework.Graphics
 open Microsoft.Xna.Framework.Input
 open Overtone.Game
 open Overtone.Game.Config
+open Overtone.Game.Constants
 
 type Control(normalTexture: Texture2D, hoverTexture: Texture2D option, position: Rectangle) =
 
@@ -32,7 +33,7 @@ module Controls =
     let Load(lifetime: Lifetime, textureManager: Textures.Manager, entry: WindowEntry) =
         let normalTexture = textureManager.LoadTexture(lifetime, entry.ShapeId, entry.ShapeFrame)
         let hoverTexture =
-            if entry.MouseFocus && entry.WindowType = 1
+            if entry.MouseFocus && entry.WindowType = WindowTypes.Button
             then Some <| textureManager.LoadTexture(lifetime, entry.ShapeId, entry.ShapeFrame + 1)
             else None
         Control(normalTexture, hoverTexture, entry.Pane)

--- a/Overtone.Game/Windows/Controls.fs
+++ b/Overtone.Game/Windows/Controls.fs
@@ -1,4 +1,4 @@
-﻿namespace Overtone.Game.Windows
+namespace Overtone.Game.Windows
 
 open JetBrains.Lifetimes
 open Microsoft.Xna.Framework
@@ -32,7 +32,7 @@ module Controls =
     let Load(lifetime: Lifetime, textureManager: Textures.Manager, entry: WindowEntry) =
         let normalTexture = textureManager.LoadTexture(lifetime, entry.ShapeId, entry.ShapeFrame)
         let hoverTexture =
-            if entry.MouseFocus
+            if entry.MouseFocus && entry.WindowType = 1
             then Some <| textureManager.LoadTexture(lifetime, entry.ShapeId, entry.ShapeFrame + 1)
             else None
         Control(normalTexture, hoverTexture, entry.Pane)

--- a/Overtone.Game/Windows/MainScene.fs
+++ b/Overtone.Game/Windows/MainScene.fs
@@ -7,13 +7,14 @@ open Microsoft.Xna.Framework.Input
 
 open Overtone.Game
 open Overtone.Game.Config
+open Overtone.Game.Constants
 open Overtone.Game.Input
 
 type MainScene(lifetime: Lifetime,
                device: GraphicsDevice,
                textureManager: Textures.Manager,
                config: WindowsConfiguration) =
-    let mutable sceneId = 0 // "Starting state" of windows.txt
+    let mutable sceneId = Scenes.MainMenu // "Starting state" of windows.txt
 
     let mutable controls = config.GetControlsArray sceneId
     let loadControl element = Controls.Load(lifetime, textureManager, element)
@@ -36,7 +37,7 @@ type MainScene(lifetime: Lifetime,
 
     member _.Update(time: GameTime, mouseState: MouseState): unit =
         allControls |> Array.iter(fun c -> c.Update mouseState)
-        if sceneId = 0 then
+        if sceneId = Scenes.MainMenu then
             sparkles.Update time
 
     member _.Draw(): unit =
@@ -44,7 +45,7 @@ type MainScene(lifetime: Lifetime,
         batch.Begin()
         for control in allControls do
             control.Draw batch
-        if sceneId = 0 then
+        if sceneId = Scenes.MainMenu then
             sparkles.Draw batch
         batch.End()
 

--- a/Overtone.Game/Windows/MainScene.fs
+++ b/Overtone.Game/Windows/MainScene.fs
@@ -9,37 +9,43 @@ open Overtone.Game
 open Overtone.Game.Config
 open Overtone.Game.Input
 
-type MenuScene(lifetime: Lifetime,
+type MainScene(lifetime: Lifetime,
                device: GraphicsDevice,
                textureManager: Textures.Manager,
                config: WindowsConfiguration) =
-    let sceneId = 0 // "Starting state" of windows.txt
+    let mutable sceneId = 0 // "Starting state" of windows.txt
 
-    let controls = config.GetControls sceneId
-    let loadControl id = Controls.Load(lifetime, textureManager, controls[id])
-    let background = loadControl "BACKGRND"
-    let title = Control(
-        textureManager.LoadTexture(lifetime, Shapes.TitleScreen.Id, Shapes.TitleScreen.TitleFrame),
-        None,
-        Rectangle(0, -41, 640, 480)
-    )
-    let newGameButton = loadControl "NEWGAME"
-    let exitButton = loadControl "EXITAPP"
-    let resumeButton = loadControl "RESUME"
-    let loadButton = loadControl "LOADGAME"
-    let allControls = [| background; title; newGameButton; exitButton; resumeButton; loadButton |]
+    let mutable controls = config.GetControlsArray sceneId
+    let loadControl element = Controls.Load(lifetime, textureManager, element)
+
+    // let title = Control(
+    //     textureManager.LoadTexture(lifetime, Shapes.TitleScreen.Id, Shapes.TitleScreen.TitleFrame),
+    //     None,
+    //     Rectangle(0, -41, 640, 480),
+    // )
+    let mutable allControls = [| |]
     let sparkles = Sparkles(lifetime, device)
+
+    member _.changeSceneId(newSceneId: int): unit=
+        sceneId <- newSceneId;
+        controls <- config.GetControlsArray sceneId
+        allControls <- controls
+        |> Seq.map(fun e -> loadControl e)
+        |> Seq.toArray
+
 
     member _.Update(time: GameTime, mouseState: MouseState): unit =
         allControls |> Array.iter(fun c -> c.Update mouseState)
-        sparkles.Update time
+        if sceneId = 0 then
+            sparkles.Update time
 
     member _.Draw(): unit =
         use batch = new SpriteBatch(device)
         batch.Begin()
         for control in allControls do
             control.Draw batch
-        sparkles.Draw batch
+        if sceneId = 0 then
+            sparkles.Draw batch
         batch.End()
 
     interface IScene with

--- a/Overtone.Game/Windows/MainScene.fs
+++ b/Overtone.Game/Windows/MainScene.fs
@@ -1,4 +1,4 @@
-﻿namespace Overtone.Game.Windows
+namespace Overtone.Game.Windows
 
 open JetBrains.Lifetimes
 open Microsoft.Xna.Framework
@@ -19,12 +19,12 @@ type MainScene(lifetime: Lifetime,
     let mutable controls = config.GetControlsArray sceneId
     let loadControl element = Controls.Load(lifetime, textureManager, element)
 
-    // let title = Control(
-    //     textureManager.LoadTexture(lifetime, Shapes.TitleScreen.Id, Shapes.TitleScreen.TitleFrame),
-    //     None,
-    //     Rectangle(0, -41, 640, 480),
-    // )
-    let mutable allControls = [| |]
+    let title = Control(
+        textureManager.LoadTexture(lifetime, Shapes.TitleScreen.Id, Shapes.TitleScreen.TitleFrame),
+        None,
+        Rectangle(0, -41, 640, 480)
+    )
+    let mutable allControls: Control[] = [||]
     let sparkles = Sparkles(lifetime, device)
 
     member _.changeSceneId(newSceneId: int): unit=
@@ -47,6 +47,8 @@ type MainScene(lifetime: Lifetime,
             control.Draw batch
         if sceneId = Scenes.MainMenu then
             sparkles.Draw batch
+            title.Draw batch
+
         batch.End()
 
     interface IScene with

--- a/Overtone.Tests/Game/Windows/WindowConfigurationTest.fs
+++ b/Overtone.Tests/Game/Windows/WindowConfigurationTest.fs
@@ -81,3 +81,66 @@ let ``WindowConfiguration should read correctly``(): unit =
             OpenPane = ValueSome <| Rectangle(1, 1, width = 4, height = 4)
         }
     |], config.Entries)
+
+[<Fact>]
+let ``WindowConfiguration GetControls should output elements assigned only to the sceneId``(): unit =
+    let bytes = Encoding.UTF8.GetBytes mockedConfig
+    let config = WindowsConfiguration.Read bytes
+
+    let emptyEntry = {
+        WindowType = 0
+        Name = ""
+        States = Set.empty
+        ShapeId = ""
+        ShapeFrame = 0
+        MouseFocus = false
+        Pane = Rectangle.Empty
+        Message = 0, 0, 0
+        MessageDestination = ""
+        ContRedraw = ValueNone
+        NumberOfStates = ValueNone
+        HighlightFrame = ValueNone
+        MovieName = ValueNone
+        OpenPane = ValueNone
+    }
+
+    let Scene0 = config.GetControls 0
+    Assert.Equal<string>([|"XXX";"XXY"|], Scene0.Keys)
+    Assert.Equal<WindowEntry>(
+        { emptyEntry with
+            Name = "XXY"
+            States = Set.singleton 0
+            ShapeId = "SCR"
+            Pane = Rectangle(0, 0, width = 2, height = 2)
+            Message = 0, 1, 0
+            MessageDestination = "DEST"
+            NumberOfStates = ValueSome 11
+            HighlightFrame = ValueSome 4
+            OpenPane = ValueSome <| Rectangle(1, 1, width = 4, height = 4)
+        },
+        Scene0["XXY"])
+    Assert.Equal<WindowEntry>(
+        { emptyEntry with
+            Name = "XXX"
+            States = Set.ofArray [| 0; 1 |]
+            ShapeId = "SCR"
+            Pane = Rectangle(0, 0, width = 640, height = 480)
+            MessageDestination = "DEST"
+            ContRedraw = ValueSome false
+            MovieName = ValueSome "aaa.avi"
+        },
+        Scene0["XXX"])
+        
+    let Scene1 = config.GetControls 1
+    Assert.Equal<string>([|"XXX"|], Scene1.Keys)
+    Assert.Equal<WindowEntry>(
+        { emptyEntry with
+            Name = "XXX"
+            States = Set.ofArray [| 0; 1 |]
+            ShapeId = "SCR"
+            Pane = Rectangle(0, 0, width = 640, height = 480)
+            MessageDestination = "DEST"
+            ContRedraw = ValueSome false
+            MovieName = ValueSome "aaa.avi"
+        },
+        Scene0["XXX"])

--- a/Overtone.Utils/Constants.fs
+++ b/Overtone.Utils/Constants.fs
@@ -1,0 +1,24 @@
+module Overtone.Game.Constants
+
+module Scenes =
+    let MainMenu: int = 0
+    let NewGame: int = 1
+    let IslandsView: int = 2
+    let GameView: int = 3
+    // Loading and saving menus are just guesses, there is no way to look at it and know which is which, as long as we refer to those we should be fine
+    let LoadingMenu: int = 4
+    let SavingMenu: int = 5
+    let IntoMovie: int = 6
+    let OutroMovie: int = 7
+
+// TODO, fullfill types as needed
+module WindowTypes =
+    let Button: int = 1
+    let TemporaryElements: int = 2 // used in load/save and islands rendering ?
+    let Background: int = 3
+    let OverlayOverBackground: int = 4 // only used in scene 1, seems to be identical to "background"
+    let Unknown: int = 5 // used in scene 3, shape TEMPHOLE, CLIPBDX
+    let IslandView: int = 10 // actual in game, for scene 3
+    let WorldView: int = 11 // actual worlds map, for scene 2
+    let Video: int = 12
+    let DropDownMenu: int = 13

--- a/Overtone.Utils/Overtone.Utils.fsproj
+++ b/Overtone.Utils/Overtone.Utils.fsproj
@@ -6,6 +6,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <Compile Include="Constants.fs" />
         <Compile Include="Lifetimes.fs" />
         <Compile Include="Geometry.fs" />
     </ItemGroup>


### PR DESCRIPTION
I don't know what was intended, but I believe we should not have code that define what are in the scene more than what we need to have. (We shouldn't list the button there I believe)

By changing the `scene.Value.changeSceneId 0` in the Game.fs file we can try to load other scenes.

For now :

Scene 0 is properly displayed (but misses the title, and dynamic content like previously)
Scene 1 is properly displayed (but misses all the dynamic content, see bellow)
Scene 2-3 crashes due to content not being in the maps (this should not happen)
Scene 4-5 are not properly displayed (I believe it's dynamic due to the save being processed by the game to display them accordingly)
Scene 6-7 untested

get Array of controls to prevent issue in ordering images on render :

![image](https://github.com/ForNeVeR/overtone/assets/3913349/f8a27f82-50d0-4531-bcc1-26292cb49613)

This screenshots is done with the other changes like https://github.com/ForNeVeR/overtone/pull/46