### PR TITLE
Feature: partial implementation of the "new game" scene

### DIFF
--- a/Overtone.Game/Audio/SoundEffect.fs
+++ b/Overtone.Game/Audio/SoundEffect.fs
@@ -1,0 +1,3 @@
+module Overtone.Game.Audio
+
+// Todo add ability to load audio

--- a/Overtone.Game/Audio/SoundEffect.fs
+++ b/Overtone.Game/Audio/SoundEffect.fs
@@ -1,3 +1,8 @@
 module Overtone.Game.Audio
 
+open Microsoft.Xna.Framework.Audio
+
 // Todo add ability to load audio
+
+let loadSound(stream): SoundEffect=
+    SoundEffect.FromStream(stream)

--- a/Overtone.Game/Config/DescriptionConfiguration.fs
+++ b/Overtone.Game/Config/DescriptionConfiguration.fs
@@ -1,0 +1,23 @@
+namespace Overtone.Game.Config
+
+open Overtone.Resources
+
+// The file looks like that for :
+//
+// 1. Help (tonehelp.txt)
+// 1. Building Names (bldname.txt)
+// 1. Building Descriptions (bldtxt.txt)
+// 1. Glyphs + Artifacts Descriptions (plotobj.txt)
+// 1. New Game + Events texts : newtext.txt
+// 1. New Game Tribe Description : newgame.txt
+// 1. In Game text : gamey.txt
+//
+// BACKGRND
+// DESCRIPTION
+// END
+//
+// IWHallMove
+// DESCRIPTION
+// END
+//
+// ENDTEXT

--- a/Overtone.Game/Config/IslandsConfiguration.fs
+++ b/Overtone.Game/Config/IslandsConfiguration.fs
@@ -2,6 +2,22 @@ namespace Overtone.Game.Config
 
 open Overtone.Resources
 
+//
+// HIGH LEVEL FILE FORMAT
+//
+// SIZE_COUNT
+//
+// FOREACH ENTRY: (SIZE_COUNT)
+//    ISLAND_COUNT
+//    FOREACH ISLAND: (ISLAND_COUNT)
+//       ANGLE RANGE 0 SHAPEID (SERVES AS MAPID !)
+//    END
+//    UNTIL -1: (BRIDGE DEFINITIONS)
+//       ISLAND_FROM ISLAND_TO
+//    END
+// END
+//
+
 type IslandsConfiguration(names: Map<string, string>) =
 
     static member Read(shapesTxt: byte[]): IslandsConfiguration =

--- a/Overtone.Game/Config/IslandsConfiguration.fs
+++ b/Overtone.Game/Config/IslandsConfiguration.fs
@@ -43,6 +43,11 @@ type IslandData (shapedId: int, distance: int, baseAngle: int)=
 type WorldDefinition ()=
     member _.IslandData=0
 
+    member _.islands: ResizeArray<IslandData> = new ResizeArray<IslandData>()
+
+    member this.addIslandEntry(angle:int, distance:int, shapeid:int)=
+        this.islands.Add(new IslandData(shapeid,distance,angle))
+
 type IslandsConfiguration() =
 
     let mutable currentId = 0
@@ -61,8 +66,8 @@ type IslandsConfiguration() =
                 printfn($"Switch to world size {currentId}")
                 currentIsland <- 0
             | [|bridgeFrom; bridgeTo|] -> printfn($"{bridgeFrom} -> {bridgeTo}")
-            | [|angle; range; _; shapeid|] ->
-                printfn($"Island {currentIsland} shape : {shapeid} at angle {angle}, range {range}")
+            | [|angle; distance; _; shapeid|] ->
+                printfn($"Island {currentIsland} shape : {shapeid} at angle {angle}, distance {distance}")
                 currentIsland <- currentIsland + 1
             | _ -> printfn($"noop : {line}")
 

--- a/Overtone.Game/Config/ShapesConfiguration.fs
+++ b/Overtone.Game/Config/ShapesConfiguration.fs
@@ -1,4 +1,4 @@
-﻿namespace Overtone.Game.Config
+namespace Overtone.Game.Config
 
 open Overtone.Resources
 

--- a/Overtone.Game/Config/SoundsConfiguration.fs
+++ b/Overtone.Game/Config/SoundsConfiguration.fs
@@ -1,0 +1,10 @@
+namespace Overtone.Game.Config
+
+open Overtone.Resources
+
+// The file looks like that for sound.txt
+//
+// effect  bhood       data\bhood.wav
+// tune    tribe0      protect.wav
+// effect  bhood       data\bhood.wav
+// TYPE NAME FILEPATH

--- a/Overtone.Game/Config/SoundsConfiguration.fs
+++ b/Overtone.Game/Config/SoundsConfiguration.fs
@@ -1,5 +1,6 @@
 namespace Overtone.Game.Config
 
+open System
 open Overtone.Resources
 
 // The file looks like that for sound.txt
@@ -8,3 +9,34 @@ open Overtone.Resources
 // tune    tribe0      protect.wav
 // effect  bhood       data\bhood.wav
 // TYPE NAME FILEPATH
+
+// typeOfSound is either :
+// 1. effect -> Played on events
+// 1. tune -> Background music
+// Playing any tune MUST stop previous tune
+// Effect are all free to happen anytime and halts nothing
+
+type SoundConfig(name:string, typeOfSound:string, path:string)=
+    member _.name= name
+    member _.typeOfSound= typeOfSound
+    member _.path= path
+    member _.sound= path
+
+
+type SoundsConfiguration(names: Map<string, SoundConfig>) =
+    static member Read(shapesTxt: byte[]): SoundsConfiguration =
+        shapesTxt
+        |> TextConfiguration.extractLines
+        |> Seq.map TextConfiguration.readPreformatedEntries
+        // Filter elements whose length isn't 3 !
+        |> Seq.filter(fun(array) -> array.Length = 3)
+        |> Seq.map(fun(array) -> array[1], SoundConfig(array[1],array[0], array[2]))
+        |> Map.ofSeq
+        |> SoundsConfiguration
+
+    member _.GetSoundsPath(effectName: string): string =
+        // printfn "Loading shape : %s" shapeId
+        if names.ContainsKey effectName then
+            names[effectName].path
+        else
+            effectName

--- a/Overtone.Game/Config/SpellsConfiguration.fs
+++ b/Overtone.Game/Config/SpellsConfiguration.fs
@@ -1,0 +1,17 @@
+namespace Overtone.Game.Config
+
+open Overtone.Resources
+
+// The file looks like that for spells.txt
+//
+// NAME OF THE SPELL
+// Level       1
+// MagCost     16
+// CryCost     11
+// SPELL DESCRIPTION
+// MAYBE WITH MULTILINES
+// END
+//
+
+// Level is the required level of the caster
+// MagCost/CryCost are the spell costs

--- a/Overtone.Game/Config/WindowsConfiguration.fs
+++ b/Overtone.Game/Config/WindowsConfiguration.fs
@@ -1,4 +1,4 @@
-﻿namespace Overtone.Game.Config
+namespace Overtone.Game.Config
 
 open System
 

--- a/Overtone.Game/GameState.fs
+++ b/Overtone.Game/GameState.fs
@@ -1,0 +1,32 @@
+namespace Overtone.Game
+
+open Overtone.Utils.Constants
+
+//
+// This holds the gamestate
+//
+
+module GameState =
+    let mutable currentRace: int = -1
+    let mutable currentDifficulty: int = 0
+    let mutable currentMapSize: int = 0
+
+    let handleButtonEvent() =
+        //
+        printfn("stuff !")
+
+    let ChangeDifficulty() =
+        currentDifficulty <- currentDifficulty + 1
+        if (currentDifficulty >= GameData.DifficultyCount) then
+            currentDifficulty <- 0
+            
+    let ChangeWorldSize() =
+        currentMapSize <- currentMapSize + 1
+        if (currentMapSize >= GameData.WorldSizeCount) then
+            currentMapSize <- 0
+            
+    let SelectRace(newRace: int) =
+        if newRace = currentRace then
+            currentRace <- -1
+        else
+            currentRace <- newRace

--- a/Overtone.Game/Overtone.Game.fsproj
+++ b/Overtone.Game/Overtone.Game.fsproj
@@ -7,17 +7,23 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <Compile Include="GameState.fs" />
+        <Compile Include="Config\SoundsConfiguration.fs" />
+        <Compile Include="Config\SpellsConfiguration.fs" />
+        <Compile Include="Config\DescriptionConfiguration.fs" />
         <Compile Include="Config\IslandsConfiguration.fs" />
         <Compile Include="Config\WindowsConfiguration.fs" />
         <Compile Include="Config\ShapesConfiguration.fs" />
         <Compile Include="Textures.fs" />
+        <Compile Include="Audio\SoundEffect.fs" />
         <Compile Include="UI\IDrawableUI.fs" />
         <Compile Include="UI\Image.fs" />
         <Compile Include="UI\Button.fs" />
         <Compile Include="UI\PauseMenu.fs" />
         <Compile Include="UI\Controls.fs" />
-        <Compile Include="Scenes\Sparkles.fs" />
         <Compile Include="Scenes\IScene.fs" />
+        <Compile Include="Scenes\Sparkles.fs" />
+        <Compile Include="Scenes\Planets.fs" />
         <Compile Include="Scenes\MainMenu.fs" />
         <Compile Include="Scenes\NewGame.fs" />
         <Compile Include="Scenes\Empty.fs" />

--- a/Overtone.Game/Program.fs
+++ b/Overtone.Game/Program.fs
@@ -8,6 +8,8 @@ let main(args: string[]): int =
     let discRoot = args[0]
 
     use disc = new GameDisc(discRoot)
+    let islands = new IslandsConfiguration()
+    islands.Read <| disc.GetData "data\\worldpos.txt"
     let shapesConfig = ShapesConfiguration.Read <| disc.GetConfig "shapes.txt"
     let windowsConfig = WindowsConfiguration.Read <| disc.GetConfig "windows.txt"
 

--- a/Overtone.Game/Program.fs
+++ b/Overtone.Game/Program.fs
@@ -10,6 +10,8 @@ let main(args: string[]): int =
     use disc = new GameDisc(discRoot)
     let islands = new IslandsConfiguration()
     islands.Read <| disc.GetData "data\\worldpos.txt"
+
+    let soundsConfig = SoundsConfiguration.Read <| disc.GetConfig "sound.txt"
     let shapesConfig = ShapesConfiguration.Read <| disc.GetConfig "shapes.txt"
     let windowsConfig = WindowsConfiguration.Read <| disc.GetConfig "windows.txt"
 

--- a/Overtone.Game/Scenes/Empty.fs
+++ b/Overtone.Game/Scenes/Empty.fs
@@ -7,12 +7,12 @@ open Microsoft.Xna.Framework.Input
 
 type Empty () =
     interface IScene with
+    
+        member _.DrawBackground(batch: SpriteBatch): unit = ()
 
-        member _.Draw(batch: SpriteBatch): unit =
-            printfn "Draw empty menu !"
+        member _.Draw(batch: SpriteBatch): unit = ()
 
-        member _.Update(time: GameTime, mouse: MouseState): unit =
-            printfn "Update empty menu !"
+        member _.Update(time: GameTime, mouse: MouseState): unit = ()
 
 // Ressources to display :
 

--- a/Overtone.Game/Scenes/IScene.fs
+++ b/Overtone.Game/Scenes/IScene.fs
@@ -5,5 +5,6 @@ open Microsoft.Xna.Framework.Graphics
 open Microsoft.Xna.Framework.Input
 
 type IScene =
-    abstract member Draw: SpriteBatch -> unit 
+    abstract member Draw: SpriteBatch -> unit
+    abstract member DrawBackground: SpriteBatch -> unit
     abstract member Update: GameTime * MouseState -> unit 

--- a/Overtone.Game/Scenes/MainMenu.fs
+++ b/Overtone.Game/Scenes/MainMenu.fs
@@ -18,8 +18,11 @@ type MainMenu (lifetime: Lifetime, device: GraphicsDevice, textureManager: Textu
     )
 
     interface IScene with
-        member _.Draw(batch: SpriteBatch): unit =
+
+        member _.DrawBackground(batch: SpriteBatch): unit =
             sparkles.Draw(batch)
+
+        member _.Draw(batch: SpriteBatch): unit =
             title.Draw(batch)
 
         member _.Update(time: GameTime, mouse: MouseState): unit =

--- a/Overtone.Game/Scenes/NewGame.fs
+++ b/Overtone.Game/Scenes/NewGame.fs
@@ -5,24 +5,62 @@ open Microsoft.Xna.Framework
 open Microsoft.Xna.Framework.Graphics
 open Microsoft.Xna.Framework.Input
 
-open Overtone.Utils.Constants
+open Overtone.Utils.Constants.GameData.NewGameMenu
 open Overtone.Game
-open Overtone.Game.UI
 
 type NewGame (lifetime: Lifetime, device: GraphicsDevice, textureManager: Textures.Manager) =
 
+    // Gotta love sparkles !
+    let sparkles:Sparkles = Sparkles(lifetime, device)
+    // Shapes used inside the menu !!!
+    let DifficultyRendering = textureManager.LoadWholeShape(lifetime, DifficultyRendering)
+    let GlyphRendering = textureManager.LoadWholeShape(lifetime, GlyphRendering)
+    let FloaterRendering = textureManager.LoadWholeShape(lifetime, FloaterRendering)
+    let RealmRendering = textureManager.LoadWholeShape(lifetime, RealmRendering)
+    let colorMask = Color.White
+    let mutable currentFrame = 0
 
     interface IScene with
 
+        member _.DrawBackground(batch: SpriteBatch): unit =
+            sparkles.Draw(batch)
+
         member _.Draw(batch: SpriteBatch): unit =
-            printfn "Draw main menu !"
+            currentFrame <- currentFrame + 1
+
+            // Render Difficulty
+            let difficultyTexture = DifficultyRendering[GameState.currentDifficulty]
+            batch.Draw(difficultyTexture.texture, difficultyTexture.offset + Vector2(320f,240f), colorMask)
+
+            if (GameState.currentRace <> -1) then
+                // Render Realms
+                let realmTexture = RealmRendering[GameState.currentRace]
+                batch.Draw(realmTexture.texture, realmTexture.offset + Vector2(60f,40f), colorMask)
+                let realmNextTexture = RealmRendering[(GameState.currentRace + 1) % 4]
+                batch.Draw(realmNextTexture.texture, realmNextTexture.offset + Vector2(140f,40f), colorMask)
+
+                // Render bigfloat
+                let floaterOffset = Vector2(500f,floor(15f + BigFloat.Bouncyness*cos(MathHelper.ToRadians(BigFloat.BouncynessFrequency*(float32)currentFrame))))
+                let floaterTextureBody = FloaterRendering[GameState.currentRace * BigFloat.OffsetPerRace]
+                batch.Draw(floaterTextureBody.texture, floaterOffset, colorMask)
+                let floaterTextureLegs = FloaterRendering[GameState.currentRace * BigFloat.OffsetPerRace + 1 + (currentFrame/BigFloat.FrameFrequency%BigFloat.FrameCount)]
+                batch.Draw(floaterTextureLegs.texture, floaterTextureLegs.offset-floaterTextureBody.offset+floaterOffset, colorMask)
+            
+            let glyphDist = -150f
+            let baseOffset = Vector2(320f ,240f)
+            let GlyphIndex = (currentFrame/Glyphs.FrameFrequency%Glyphs.FrameCount);
+            for x in 0..3 do
+                let glyph = GlyphRendering[x * Glyphs.OffsetPerRace + GlyphIndex];
+                let angle = MathHelper.ToRadians(90f * (float32)x)
+                batch.Draw(glyph.texture, glyph.offset + baseOffset + Vector2(glyphDist*cos(angle),glyphDist*sin(angle)), colorMask)
 
         member _.Update(time: GameTime, mouse: MouseState): unit =
-            printfn "Update main menu !"
+            sparkles.Update(time)
 
 // Ressources to display :
 
-// BIGFLOAT (anim + foreach race)
-// GLYPHS (anim + foreach race)
-// NGREALMS (foreach race)
-// LEVIDIF (depends on current dif)
+// BIGFLOAT (anim + foreach race), rendered top right
+// GLYPHS (anim + foreach race), 90° angle around the center
+// NGREALMS (foreach race), top left screen current realm + the next one that one warrior class is in, weak against the previous one
+// LEVIDIF (depends on current dif), rendered in the middle of the screen, levidif is 280x280, game size is 640x480 -> offset for rendering (180x100)
+// World size is rendered with noisy blue stuff

--- a/Overtone.Game/Scenes/Planets.fs
+++ b/Overtone.Game/Scenes/Planets.fs
@@ -1,2 +1,28 @@
+namespace Overtone.Game.Scenes
+
+open JetBrains.Lifetimes
+open Microsoft.Xna.Framework
+open Microsoft.Xna.Framework.Graphics
+open Microsoft.Xna.Framework.Input
+
+open Overtone.Utils.Constants
+open Overtone.Game
+open Overtone.Game.UI
+
+type Planets (lifetime: Lifetime, device: GraphicsDevice, textureManager: Textures.Manager) =
+    
+    // Gotta love sparkles !
+    let sparkles:Sparkles = Sparkles(lifetime, device)
+
+    interface IScene with
+
+        member _.DrawBackground(batch: SpriteBatch): unit =
+            sparkles.Draw(batch)
+
+        member _.Draw(batch: SpriteBatch): unit = ()
+
+        member _.Update(time: GameTime, mouse: MouseState): unit =
+            sparkles.Update(time)
+
 // Planet img : SMISLE
 // Planet count/position : https://github.com/Fadoli/ToneRebellion_Raw/blob/master/original_content/WORLDPOS.TXT

--- a/Overtone.Game/Scenes/SceneFactory.fs
+++ b/Overtone.Game/Scenes/SceneFactory.fs
@@ -13,6 +13,7 @@ type SceneFactory () =
             match sceneId with
             | id when id = Constants.Scenes.MainMenu -> MainMenu(lifetime,device,textureManager)
             | id when id = Constants.Scenes.NewGame -> NewGame(lifetime,device,textureManager)
+            | id when id = Constants.Scenes.IslandsView -> Planets(lifetime,device,textureManager)
             | _ -> Empty()
 
 // Ressources to display :

--- a/Overtone.Game/UI/Button.fs
+++ b/Overtone.Game/UI/Button.fs
@@ -24,7 +24,7 @@ type Button(normalTexture: Texture2DWithOffset, hoverTexture: Texture2DWithOffse
                 && mouseState.LeftButton = ButtonState.Pressed
             then
                 // Debug for now
-                printfn "should act !"
+                // printfn "should act !"
                 entry.Message
             else
                 (0, 0, 0)

--- a/Overtone.Resources/Shape.fs
+++ b/Overtone.Resources/Shape.fs
@@ -152,10 +152,10 @@ type ShapeFile(input: Stream) =
             let struct (startX, startY) = sprite.Start
             let struct (endX, endY) = sprite.End
 
-            let minCanvasX = int originX + startX
-            let minCanvasY = int originY + startY
-            let maxCanvasX = int originX + endX
-            let maxCanvasY = int originY + endY
+            let minCanvasX = int startX
+            let minCanvasY = int startY
+            let maxCanvasX = int endX
+            let maxCanvasY = int endY
             
 
             let width = (maxCanvasX - minCanvasX)

--- a/Overtone.Resources/TextConfiguration.fs
+++ b/Overtone.Resources/TextConfiguration.fs
@@ -13,11 +13,16 @@ let private clearLine(line: string) =
     else
         line
 
+// Used for `WINTYPE        1`
 let readKeyValueEntry(line: string): string*string =
     let components = line.Split([| ' '; '\t' |], 2, StringSplitOptions.RemoveEmptyEntries)
     match components with
     | [|key; value|] -> key, value
     | _ -> failwithf $"Cannot parse line: \"{line}\"."
+    
+// Used for `0       2000    0        0`
+let readPreformatedEntries(line: string): string array =
+    line.Split([| ' '; '\t' |], StringSplitOptions.RemoveEmptyEntries)
 
 /// Preprocess a text file, stripping comments and removing the empty lines.
 let extractLines(data: byte[]): string seq = seq {

--- a/Overtone.Utils/Constants.fs
+++ b/Overtone.Utils/Constants.fs
@@ -23,7 +23,31 @@ module WindowTypes =
     let Video: int = 12
     let DropDownMenu: int = 13
 
+module GameData =
+    let IslandsCount: int = 15 // Hardcoded max islands counts
+    let DifficultyCount: int = 5
+    let WorldSizeCount: int = 3
+    module NewGameMenu =
+        module Glyphs=
+            let FrameCount:int = 20
+            let OffsetPerRace:int = FrameCount
+            let FrameFrequency:int = 6 // divide frames per 6 to get the currentFrameAnim
+        module BigFloat=
+            let FrameCount:int = 16 // Main body + 16 frames for the legs
+            let OffsetPerRace:int = (1+FrameCount) // Main body + 16 frames for the legs
+            let BouncynessFrequency:float32 = 3f // change convertion between frames and radian angle of the sin
+            let Bouncyness:float32 = 3f // +- 3px in vertical position
+            let FrameFrequency:int = 6 // divide frames per 6 to get the currentFrameAnim
+        let DifficultyRendering: string = "LEVIDIFF"
+        let RealmRendering: string = "NGREALMS"
+        let FloaterRendering: string = "BIGFLOAT"
+        let GlyphRendering: string = "GLYPHS"
+
+module Sounds =
+    let Button: string = "data\\BUTTON.WAV"
+
 module Shapes =
+    let PlanetsRendering: string = "SMISLE"
     module TitleScreen =
         let Id: string = "TITSCRN"
         let TitleFrame: int = 1


### PR DESCRIPTION
This requires https://github.com/ForNeVeR/overtone/pull/50 to be merged before hands (this PRs contains the same commits)

This adds :

1. Documentation of text formats in `Overtone.Game\Config\...`
1. Dummy planet definition parser (more to come on future PRs !)
1. SoundsConfiguration reader (to map soundName to sound file path)
1. Hacky partial rendering of the new-game screen (misses texts and world size indicator)
1. Handle UI events for the new game screen + global GameState module !