### PR TITLE
Feature : add hacky sounds

### DIFF
--- a/Overtone.Game/Config/IslandsConfiguration.fs
+++ b/Overtone.Game/Config/IslandsConfiguration.fs
@@ -53,7 +53,7 @@ type IslandsConfiguration() =
     let mutable currentId = 0
     let mutable currentIsland = 0
 
-    member this.Read(shapesTxt: byte[]): unit =
+    member _.Read(shapesTxt: byte[]): unit =
 
         let mutable currentWorldEdition = new WorldDefinition()
         let mutable islandData = new IslandData(0,0,0)

--- a/Overtone.Game/Config/ShapesConfiguration.fs
+++ b/Overtone.Game/Config/ShapesConfiguration.fs
@@ -8,7 +8,7 @@ type ShapesConfiguration(names: Map<string, string>) =
         shapesTxt
         |> TextConfiguration.extractLines
         |> Seq.map TextConfiguration.readKeyValueEntry
-        |> Seq.map(fun(a, b) -> b, a)
+        |> Seq.map(fun(a, b) -> b.ToUpper(), a.ToUpper())
         |> Map.ofSeq
         |> ShapesConfiguration
 

--- a/Overtone.Game/GameState.fs
+++ b/Overtone.Game/GameState.fs
@@ -1,6 +1,8 @@
 namespace Overtone.Game
 
 open Overtone.Utils.Constants
+open Overtone.Game.Config
+open Overtone.Resources
 
 //
 // This holds the gamestate
@@ -10,6 +12,30 @@ module GameState =
     let mutable currentRace: int = -1
     let mutable currentDifficulty: int = 0
     let mutable currentMapSize: int = 0
+    let mutable discRoot: string = ""
+    let mutable disc: Option<GameDisc> = None
+
+    let mutable soundsConfig: SoundsConfiguration= new SoundsConfiguration(Map.empty)
+    let mutable shapesConfig: ShapesConfiguration= new ShapesConfiguration(Map.empty)
+
+
+    let init(rootPath): unit=
+        discRoot <- rootPath
+        let currentDisc = new GameDisc(rootPath)
+        disc <- Some(currentDisc)
+        let islands = new IslandsConfiguration()
+        islands.Read <| currentDisc.GetData "data\\worldpos.txt"
+        soundsConfig <- SoundsConfiguration.Read <| currentDisc.GetConfig "sound.txt"
+        shapesConfig <- ShapesConfiguration.Read <| currentDisc.GetConfig "shapes.txt"
+        // windowsConfig <- WindowsConfiguration.Read <| currentDisc.GetConfig "windows.txt"
+
+    let getDisc(): GameDisc=
+        match disc with
+            | Some(output) -> output
+            | None ->
+                let output = new GameDisc(discRoot)
+                output
+
 
     let handleButtonEvent() =
         //

--- a/Overtone.Game/Overtone.Game.fsproj
+++ b/Overtone.Game/Overtone.Game.fsproj
@@ -7,13 +7,13 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <Compile Include="GameState.fs" />
         <Compile Include="Config\SoundsConfiguration.fs" />
         <Compile Include="Config\SpellsConfiguration.fs" />
         <Compile Include="Config\DescriptionConfiguration.fs" />
         <Compile Include="Config\IslandsConfiguration.fs" />
         <Compile Include="Config\WindowsConfiguration.fs" />
         <Compile Include="Config\ShapesConfiguration.fs" />
+        <Compile Include="GameState.fs" />
         <Compile Include="Textures.fs" />
         <Compile Include="Audio\SoundEffect.fs" />
         <Compile Include="UI\IDrawableUI.fs" />

--- a/Overtone.Game/Program.fs
+++ b/Overtone.Game/Program.fs
@@ -7,16 +7,17 @@ open Overtone.Resources
 let main(args: string[]): int =
     let discRoot = args[0]
 
-    use disc = new GameDisc(discRoot)
+    GameState.discRoot <- discRoot
+    GameState.init(discRoot)
     let islands = new IslandsConfiguration()
-    islands.Read <| disc.GetData "data\\worldpos.txt"
+    islands.Read <| GameState.getDisc().GetData "data\\worldpos.txt"
 
-    let soundsConfig = SoundsConfiguration.Read <| disc.GetConfig "sound.txt"
-    let shapesConfig = ShapesConfiguration.Read <| disc.GetConfig "shapes.txt"
-    let windowsConfig = WindowsConfiguration.Read <| disc.GetConfig "windows.txt"
+    let soundsConfig = SoundsConfiguration.Read <| GameState.getDisc().GetConfig "sound.txt"
+    let shapesConfig = ShapesConfiguration.Read <| GameState.getDisc().GetConfig "shapes.txt"
+    let windowsConfig = WindowsConfiguration.Read <| GameState.getDisc().GetConfig "windows.txt"
 
-    use game = new OvertoneGame(disc, shapesConfig, windowsConfig)
-    let mainTheme = soundsConfig.GetSoundPerName("START.WAV",disc)
+    use game = new OvertoneGame(GameState.getDisc(), shapesConfig, windowsConfig)
+    let mainTheme = soundsConfig.GetSoundPerName("START.WAV",GameState.getDisc())
     mainTheme.Play() |> ignore
     game.Run()
     0

--- a/Overtone.Game/Program.fs
+++ b/Overtone.Game/Program.fs
@@ -16,5 +16,7 @@ let main(args: string[]): int =
     let windowsConfig = WindowsConfiguration.Read <| disc.GetConfig "windows.txt"
 
     use game = new OvertoneGame(disc, shapesConfig, windowsConfig)
+    let mainTheme = soundsConfig.GetSoundPerName("START.WAV",disc)
+    mainTheme.Play() |> ignore
     game.Run()
     0

--- a/Overtone.Game/UI/Button.fs
+++ b/Overtone.Game/UI/Button.fs
@@ -7,6 +7,7 @@ open Microsoft.Xna.Framework.Input
 
 open Overtone.Game.Config
 open Overtone.Game.Textures
+open Overtone.Game
 
 
 type Button(normalTexture: Texture2DWithOffset, hoverTexture: Texture2DWithOffset, entry: WindowEntry) =
@@ -25,6 +26,8 @@ type Button(normalTexture: Texture2DWithOffset, hoverTexture: Texture2DWithOffse
             then
                 // Debug for now
                 // printfn "should act !"
+                let sound = GameState.soundsConfig.GetSoundPerName("BUTTON",GameState.getDisc())
+                sound.Play() |> ignore
                 entry.Message
             else
                 (0, 0, 0)

--- a/Overtone.Resources/GameDisc.fs
+++ b/Overtone.Resources/GameDisc.fs
@@ -18,21 +18,24 @@ type GameDisc(rootPath: string) =
 
     let configEntries =
         configArchive.ReadEntries()
-        |> Seq.map(fun e -> e.Path, e)
+        |> Seq.map(fun e -> e.Path.ToUpper(), e)
         |> Map.ofSeq
     let dataEntries =
         dataArchive.ReadEntries()
-        |> Seq.map(fun e -> e.Path, e)
+        |> Seq.map(fun e -> e.Path.ToUpper(), e)
         |> Map.ofSeq
+
+    member _.ReadFileAsStream(relativePath: string): FileStream =
+        Path.Combine(rootPath, relativePath) |> File.OpenRead
 
     member _.ReadFile(relativePath: string): Task<byte[]> =
         Path.Combine(rootPath, relativePath) |> File.ReadAllBytesAsync
 
-    member _.GetConfig(name: string): byte[] = configEntries[name] |> configArchive.ReadEntry
-    member _.GetData(name: string): byte[] = dataEntries[name] |> dataArchive.ReadEntry
+    member _.GetConfig(name: string): byte[] = configEntries[name.ToUpper()] |> configArchive.ReadEntry
+    member _.GetData(name: string): byte[] = dataEntries[name.ToUpper()] |> dataArchive.ReadEntry
 
     member _.hasDataEntry(name: string): bool = 
-        dataEntries.ContainsKey name
+        dataEntries.ContainsKey (name.ToUpper())
 
     interface IDisposable with
         member _.Dispose() =

--- a/Overtone.Resources/ShapePalette.fs
+++ b/Overtone.Resources/ShapePalette.fs
@@ -1,4 +1,4 @@
-﻿module Overtone.Resources.ShapePalette
+module Overtone.Resources.ShapePalette
 
 open System
 open System.IO
@@ -10,7 +10,7 @@ let private (|Island|_|): string -> string option = function
 | _ -> None
 
 let get(shapeFilePath: string): string =
-    let name = Path.GetFileName shapeFilePath
+    let name = (Path.GetFileName (shapeFilePath)).ToLower()
     let resName =
         match name with
         | Island(number) -> $"island{number}.pal"
@@ -27,7 +27,7 @@ let get(shapeFilePath: string): string =
 
 let getWithDisk(shapeFilePath: string, disc: GameDisc): string =
     let name = Path.GetFileName shapeFilePath
-    let simpleRename = "data\\"+Path.ChangeExtension(name, "pal")
+    let simpleRename = "data\\"+Path.ChangeExtension(name, "pal").ToUpper()
     if disc.hasDataEntry simpleRename
     then
         simpleRename


### PR DESCRIPTION
This requires change so that everything is either forced to be uppercase or lowercase, because there are mismatch of filepaths.

This implements a simple POC for sounds just to demonstrate how we could do it later on, it includes button click (this feels good) and the startup sound. There are no loops or anything like that, as already stated this is just a proof of concept for playing the audio and loading it

It moves more stuff to the gameState as we need to have a unified place that'll store all the game data